### PR TITLE
update example to work with nightly 1.4.0-dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,12 @@ license = "MIT"
 [dependencies]
 kernel32-sys = "*"
 winapi = "*"
+
+[[example]]
+name = "example"
+path = "examples/main.rs"
+
+[dev_dependencies]
+num_cpus = "*"
+threadpool = "*"
+rand = "*"


### PR DESCRIPTION
replaces built-in num_cpus with crate
replaces taskpool with threadpool crate
replaces bulit-in rand with crate
